### PR TITLE
Added annotation examples from OMEX Metadata Spec 1.0.

### DIFF
--- a/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalEntityExample.rdf
+++ b/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalEntityExample.rdf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+  
+   <!--
+        This composite semantic annotation indicates that the element with 
+		metadata ID "VLV" in file "MyModel.xml" represents the volume of blood in the 
+		left coronary artery.
+   -->
+   
+   <rdf:Description rdf:about="./MyModel.xml#VLV">
+		<bqbiol:isVersionOf rdf:resource="http://identifiers.org/opb/OPB_00154" />
+		<bqbiol:isPropertyOf rdf:resource="#entity_0"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="#entity_0">
+		<bqbiol:is rdf:resource="http://identifiers.org/fma/FMA:9670" />
+		<bqbiol:isPartOf rdf:resource="http://identifiers.org/fma/FMA:18228"/>
+	</rdf:Description>
+
+</rdf:RDF>

--- a/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalForceExample.rdf
+++ b/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalForceExample.rdf
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:bqbiol="http://biomodels.net/biology-qualifiers/"
+	xmlns:semsim="http://www.bhi.washington.edu/semsim#">
+  
+   <!--
+        This is an example composite semantic annotation for a property of a physical
+		force. The annotation indicates that the element with metadata ID "parameter_metaid_0"
+		in file "MyModel.sbml" represents the cellular membrane potential established by one source
+		participant and one sink participant. The source and sink participants refer to elements
+		in the model with metadata IDs "species_metaid_0" and "species_metaid_1". Not shown here are 
+		the additional annotations on these species that would be needed to establish their 
+		chemical identities and compartmental locations.
+   -->
+   
+   <rdf:Description rdf:about="./MyModel.sbml#parameter_metaid_0">
+		<bqbiol:isPropertyOf rdf:resource="./MyModel.sbml#force_0"/>
+		<bqbiol:isVersionOf rdf:resource="https://identifiers.org/opb/OPB_01058"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.sbml#force_0">
+		<semsim:hasSourceParticipant rdf:resource="./MyModel.sbml#source_0"/>
+		<semsim:hasSinkParticipant rdf:resource="./MyModel.sbml#sink_0"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.sbml#source_0">
+		<semsim:hasPhysicalEntityReference rdf:resource="./MyModel.sbml#species_metaid_0"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.sbml#sink_0">
+		<semsim:hasPhysicalEntityReference rdf:resource="./MyModel.sbml#species_metaid_1"/>
+	</rdf:Description>
+
+</rdf:RDF>

--- a/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalProcessExample.rdf
+++ b/standardized/OMEX Metadata 1.0 examples/PropertyOfPhysicalProcessExample.rdf
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:bqbiol="http://biomodels.net/biology-qualifiers/"
+	xmlns:semsim="http://www.bhi.washington.edu/semsim#">
+  
+   <!--
+        This is an example composite semantic annotation for a property of a physical
+		process. The annotation indicates that the element with metadata ID "property_metaid_0"
+		in file "MyModel.xml" represents the chemical flow rate of a process with metadata ID 
+		"process_metaid_0". The process has one source participant (stoichiometry of 1), 
+		one sink participant (stoichiometry of 2), and one mediator. Not shown here are 
+		the additional annotations on the species participants that would be needed to establish
+		their chemical identities and compartmental locations.
+   -->
+   
+   <rdf:Description rdf:about="./MyModel.xml#property_metaid_0">
+		<bqbiol:isPropertyOf rdf:resource="./MyModel.xml#process_metaid_0"/>
+		<bqbiol:isVersionOf rdf:resource="https://identifiers.org/opb/OPB_00592"/>
+	</rdf:Description>
+	
+	<rdf:Description rdf:about="./MyModel.xml#process_metaid_0">
+		<semsim:hasSourceParticipant rdf:resource="./MyModel.xml#source_0"/>
+		<semsim:hasSinkParticipant rdf:resource="./MyModel.xml#sink_0"/>
+		<semsim:hasMediatorParticipant rdf:resource="./MyModel.xml#mediator_0"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.xml#source_0">
+		<semsim:hasMultiplier>1.0</semsim:hasMultiplier>
+		<semsim:hasPhysicalEntityReference rdf:resource="./MyModel.xml#species_metaid_0"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.xml#sink_0">
+		<semsim:hasMultiplier>2.0</semsim:hasMultiplier>
+		<semsim:hasPhysicalEntityReference rdf:resource="./MyModel.xml#species_metaid_1"/>
+	</rdf:Description>
+
+	<rdf:Description rdf:about="./MyModel.xml#mediator_0">
+		<semsim:hasPhysicalEntityReference rdf:resource="./MyModel.xml#species_metaid_2"/>
+	</rdf:Description>
+
+</rdf:RDF>

--- a/standardized/OMEX Metadata 1.0 examples/README.md
+++ b/standardized/OMEX Metadata 1.0 examples/README.md
@@ -1,0 +1,1 @@
+This folder contains annotation examples in RDF/XML format from the OMEX Metadata Specification version 1.0.

--- a/standardized/OMEX Metadata 1.0 examples/SingularAnnotationExamples.rdf
+++ b/standardized/OMEX Metadata 1.0 examples/SingularAnnotationExamples.rdf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:bqbiol="http://biomodels.net/biology-qualifiers/"
+	xmlns:bqmodel="http://biomodels.net/model-qualifiers/"
+	xmlns:dcterms="http://purl.org/dc/terms/">
+  
+   <!--
+        This is an example of a singular, model-level, non-semantic annotation that indicates the
+		PubMed ID of the model’s source publication. In this case, the metadata ID for the model as a whole
+		(e.g., the metadata ID associated with the <model> element in an SBML model) is "modelmeta1":
+   -->
+
+   <rdf:Description rdf:about="./MyModel.xml#modelmeta1">
+		<bqmodel:isDescribedBy rdf:resource="https://identifiers.org/pubmed/12991237" />
+	</rdf:Description>
+	
+	
+	<!--
+		This is an example singular semantic annotation indicating that the element with metadata ID
+		"meta1" from the file "MyModel.xml" represents adenosine tri-phosphate:
+	-->
+	
+	<rdf:Description rdf:about="./MyModel.xml#meta1">
+		<bqbiol:is rdf:resource="https://identifiers.org/chebi/CHEBI:15422" />
+	</rdf:Description>
+
+
+	<!--
+		This is an example free-text description of a model variable with metadata ID "meta2":
+	-->
+	
+	<rdf:Description rdf:about="./MyModel.xml#meta2">
+		<dcterms:description>Cardiomyocyte cytosolic ATP concentration</dcterms:description>
+	</rdf:Description>
+
+</rdf:RDF>


### PR DESCRIPTION
RDF/XML annotation examples from the 1.0 version of the OMEX metadata specification were added to the "standardized" folder.